### PR TITLE
Changed to use Next.js's Script component instead of HTML's script tag

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
     "next": ">=9.0.0",
     "react": ">=16.8.0"
   },
-  "dependencies": {},
+  "dependencies": {
+    "next": "^15.3.4"
+  },
   "devDependencies": {
     "@types/node": "^14.0.0 || ^16.0.0 || ^18.0.0 || ^20.0.0",
     "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",

--- a/src/VWOScript.tsx
+++ b/src/VWOScript.tsx
@@ -15,6 +15,7 @@
  */
 
 import React from 'react';
+import Script from 'next/script';
 
 interface VWOScriptProps {
   accountId: string;
@@ -67,7 +68,7 @@ export const VWOScript: React.FC<VWOScriptProps> = ({
           href="https://dev.visualwebsiteoptimizer.com"
           {...linkAttributes}
         />
-        <script
+        <Script
           {...scriptAttributes}
           type="text/javascript"
           id="vwoCode"


### PR DESCRIPTION
Changed to use Next.js's Script component instead of HTML's script tag so the VWOScript component could still work when nested inside other custom components